### PR TITLE
Add badge for GitHub Actions instead of TravisCI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # mustache.el
 #### *a mustache templating library in Emacs Lisp*
 
-[![Build Status](https://travis-ci.org/Wilfred/mustache.el.png?branch=master)](https://travis-ci.org/Wilfred/mustache.el)
+[![Main workflow](https://github.com/Wilfred/mustache.el/workflows/Main%20workflow/badge.svg)](https://github.com/Wilfred/mustache.el/actions)
 
 Targeting [v.1.0.2](https://github.com/mustache/spec/tree/v1.0.2) of Mustache.
 


### PR DESCRIPTION
Hi, I forgot to change CI badge.
This PR add badge for GitHub Actions instead of TravisCI.