### PR TITLE
Fix package-lint/byte-compile/check-doc warnings

### DIFF
--- a/mustache.el
+++ b/mustache.el
@@ -6,6 +6,7 @@
 ;; Version: 0.24
 ;; Keywords: mustache, template
 ;; Package-Requires: ((ht "0.9") (s "1.3.0") (dash "1.2.0"))
+;; URL: https://github.com/Wilfred/mustache.el
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by

--- a/mustache.el
+++ b/mustache.el
@@ -4,7 +4,7 @@
 
 ;; Author: Wilfred Hughes <me@wilfred.me.uk>
 ;; Version: 0.24
-;; Keywords: mustache, template
+;; Keywords: convenience mustache template
 ;; Package-Requires: ((ht "0.9") (s "1.3.0") (dash "1.2.0"))
 ;; URL: https://github.com/Wilfred/mustache.el
 

--- a/mustache.el
+++ b/mustache.el
@@ -61,8 +61,7 @@ For 'string we expect contexts of the form:
 #s\(hash-table data \(\"name\" \"J. Random user\"\)\)
 
 for 'keyword we expect contexts of the form:
-#s\(hash-table data \(:name \"J. Random user\"\)\)
-")
+#s\(hash-table data \(:name \"J. Random user\"\)\)")
 
 (provide 'mustache)
 ;;; mustache.el ends here

--- a/mustache.el
+++ b/mustache.el
@@ -1,4 +1,4 @@
-;;; mustache.el --- a mustache templating library in emacs lisp
+;;; mustache.el --- Mustache templating library in emacs lisp
 
 ;; Copyright (C) 2013 Wilfred Hughes
 

--- a/mustache.el
+++ b/mustache.el
@@ -43,6 +43,8 @@
 
 (load "mustache-render.el")
 
+(declare-function mst--render "mustache-render")
+
 ;; todo: add flag to set tolerance of missing variables
 (defun mustache-render (template context)
   "Render a mustache TEMPLATE with hash table CONTEXT."


### PR DESCRIPTION
I found package-lint/byte-compile/check-doc warnings/errors for mustache.el

### before
    mustache.…     1   1 error           Package should have a Homepage or URL header. (emacs-lisp-package)
    mustache.…     1   1 warning         The package summary should start with an uppercase letter or a digit. (emacs-lisp-package)
    mustache…     7   4 warning         You should include standard keywords: see the variable `finder-known-keywords'. (emacs-lisp-package)
    mustache…    61     info            Documentation strings should not start or end with whitespace (emacs-lisp-checkdoc)
    mustache…    66   1 warning         the function ‘mst--render’ is not known to be defined. (emacs-lisp)

### after
```
No warnings
```