### PR TITLE
Use require instead of load, provide each features

### DIFF
--- a/mustache-lex.el
+++ b/mustache-lex.el
@@ -1,17 +1,30 @@
+;;; mustache-lex.el --- Mustache lex module
+
+;; Copyright (C) 2013 Wilfred Hughes
+
+;; Author: Wilfred Hughes <me@wilfred.me.uk>
+;; URL: https://github.com/Wilfred/mustache.el
+
 ;; This file is part of mustache.el.
-;;
+
 ;; mustache.el is free software: you can redistribute it and/or modify it
 ;; under the terms of the GNU General Public License as published by
 ;; the Free Software Foundation, either version 3 of the License, or
 ;; (at your option) any later version.
-;;
+
 ;; mustache.el is distributed in the hope that it will be useful, but
 ;; WITHOUT ANY WARRANTY; without even the implied warranty of
 ;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 ;; General Public License for more details.
-;;
+
 ;; You should have received a copy of the GNU General Public License
 ;; along with mustache.el.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; Mustache lex module.
+
+;;; Code:
 
 (eval-when-compile (require 'cl)) ;; first, second, destructuring-bind, loop
 (require 's)
@@ -164,3 +177,6 @@ return the original input string."
           (let ((text (second lexeme)))
             (concat text (mst--unlex rest))))))
     ""))
+
+(provide 'mustache-lex)
+;;; mustache-lex.el ends here

--- a/mustache-parse.el
+++ b/mustache-parse.el
@@ -1,17 +1,30 @@
+;;; mustache-parse.el --- Mustache parse module
+
+;; Copyright (C) 2013 Wilfred Hughes
+
+;; Author: Wilfred Hughes <me@wilfred.me.uk>
+;; URL: https://github.com/Wilfred/mustache.el
+
 ;; This file is part of mustache.el.
-;;
+
 ;; mustache.el is free software: you can redistribute it and/or modify it
 ;; under the terms of the GNU General Public License as published by
 ;; the Free Software Foundation, either version 3 of the License, or
 ;; (at your option) any later version.
-;;
+
 ;; mustache.el is distributed in the hope that it will be useful, but
 ;; WITHOUT ANY WARRANTY; without even the implied warranty of
 ;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 ;; General Public License for more details.
-;;
+
 ;; You should have received a copy of the GNU General Public License
 ;; along with mustache.el.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; Mustache parse module.
+
+;;; Code:
 
 (require 's)
 (eval-when-compile (require 'cl)) ;; loop, return
@@ -68,3 +81,6 @@
   "Get the name of the section from LEXEME, a two part list returned by `mst--lex'.
 The leading character (the #, ^ or /) is stripped."
   (s-chop-prefixes '("#" "^" "/") (cadr lexeme)))
+
+(provide 'mustache-parse)
+;;; mustache-parse.el ends here

--- a/mustache-render.el
+++ b/mustache-render.el
@@ -32,8 +32,8 @@
 
 (eval-when-compile '(require 'cl)) ;; return, dolist
 
-(load "mustache-lex.el")
-(load "mustache-parse.el")
+(require 'mustache-lex)
+(require 'mustache-parse)
 
 (defun mst--render (template context)
   "Render a mustache TEMPLATE with hash table CONTEXT."

--- a/mustache-render.el
+++ b/mustache-render.el
@@ -1,17 +1,30 @@
+;;; mustache-render.el --- Mustache render module
+
+;; Copyright (C) 2013 Wilfred Hughes
+
+;; Author: Wilfred Hughes <me@wilfred.me.uk>
+;; URL: https://github.com/Wilfred/mustache.el
+
 ;; This file is part of mustache.el.
-;;
+
 ;; mustache.el is free software: you can redistribute it and/or modify it
 ;; under the terms of the GNU General Public License as published by
 ;; the Free Software Foundation, either version 3 of the License, or
 ;; (at your option) any later version.
-;;
+
 ;; mustache.el is distributed in the hope that it will be useful, but
 ;; WITHOUT ANY WARRANTY; without even the implied warranty of
 ;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 ;; General Public License for more details.
-;;
+
 ;; You should have received a copy of the GNU General Public License
 ;; along with mustache.el.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; Mustache render module.
+
+;;; Code:
 
 (require 'ht)
 (require 's)
@@ -153,3 +166,6 @@ render it in CONTEXT."
     (s-replace ">" "&gt;")
     (s-replace "'" "&#39;")
     (s-replace "\"" "&quot;")))
+
+(provide 'mustache-render)
+;;; mustache-render.el ends here

--- a/mustache-tests.el
+++ b/mustache-tests.el
@@ -1,17 +1,30 @@
+;;; mustache-test.el --- Mustache test module
+
+;; Copyright (C) 2013 Wilfred Hughes
+
+;; Author: Wilfred Hughes <me@wilfred.me.uk>
+;; URL: https://github.com/Wilfred/mustache.el
+
 ;; This file is part of mustache.el.
-;;
+
 ;; mustache.el is free software: you can redistribute it and/or modify it
 ;; under the terms of the GNU General Public License as published by
 ;; the Free Software Foundation, either version 3 of the License, or
 ;; (at your option) any later version.
-;;
+
 ;; mustache.el is distributed in the hope that it will be useful, but
 ;; WITHOUT ANY WARRANTY; without even the implied warranty of
 ;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 ;; General Public License for more details.
-;;
+
 ;; You should have received a copy of the GNU General Public License
 ;; along with mustache.el.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; Mustache test module.
+
+;;; Code:
 
 (require 'mustache)
 (require 'ert)

--- a/mustache.el
+++ b/mustache.el
@@ -41,7 +41,7 @@
 
 ;;; Code:
 
-(load "mustache-render.el")
+(require 'mustache-render)
 
 (declare-function mst--render "mustache-render")
 


### PR DESCRIPTION
The use of load is rare and require is usually recommended.
Larger software, such as magit, also uses this approach.
This change also solves check-doc and package-lint warnings, such as
```
 mustache-…     0     info            The first line should be of the form: ";;; package --- Summary" (emacs-lisp-checkdoc)
 mustache…     0     info            You should have a section marked ";;; Commentary:" (emacs-lisp-checkdoc)
 mustache…    20     info            You should have a section marked ";;; Code:" (emacs-lisp-checkdoc)
 mustach…   155     info            The footer should be: (provide 'mustache-render)\n;;; mustache-render.el ends here (emacs-lisp-checkdoc)
 mustach…   156   1 warning         the following functions are not known to be defined: mst--parse, mst--clean-whitespace, mst--lex, return, mst--tag-text, mst--comment-tag-p, mst--unescaped-tag-p, mst--partial-tag-p, mst--section-p, first, mst--open-section-tag-p, mst--unlex, mst--inverted-section-tag-p, mst--tag-p, second (emacs-lisp)
```