### PR TITLE
Use actions/checkout@v2 and actions/setup-python@v2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,8 +21,8 @@ jobs:
           - emacs_version: 'snapshot'
             allow_failure: true
     steps:
-    - uses: actions/checkout@v1
-    - uses: actions/setup-python@v1.1.1
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
     - uses: purcell/setup-emacs@master
       with:
         version: ${{ matrix.emacs_version }}


### PR DESCRIPTION
Use actions/checkout@v2 and actions/setup-python@v2.
Now, GHA requires related API.  See below error
```
Run actions/setup-python@v1.1.1
Error: Unable to process command '##[set-env name=pythonLocation;]/opt/hostedtoolcache/Python/3.9.1/x64' successfully.
Error: The `set-env` command is disabled. Please upgrade to using Environment Files or opt into unsecure command execution by setting the `ACTIONS_ALLOW_UNSECURE_COMMANDS` environment variable to `true`. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
```