### PR TITLE
Add alist context support

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,14 @@ Error checking on invalid sections:
      "{{#outer}}{{#inner}}mismatched!{{/outer}}{{/inner}}"
      (ht)) ;; error "Mismatched brackets: You closed a section with inner, but it wasn't open"
 
+## Alist support
+
+For cusual usage, you can specify using alist for context
+
+    (let ((context '(("name" . "J. Random user"))))
+      (mustache-render "Hello {{name}}!" context))
+    ;;=> "Hello J. Random user!"
+
 ## Todo:
 
 * Errors on unclosed tags

--- a/mustache-render.el
+++ b/mustache-render.el
@@ -79,6 +79,8 @@ Partials are searched for in `mustache-partial-paths'."
 
 (defun mst--context-get (context variable-name &optional default)
   "Lookup VARIABLE-NAME in CONTEXT, returning DEFAULT if not present."
+  (unless (ht-p context)
+    (setq context (ht<-alist context)))
   (when (eq mustache-key-type 'keyword)
     (setq variable-name (intern (concat ":" variable-name))))
   (ht-get context variable-name default))


### PR DESCRIPTION
Add alist context support.
For cusual usage, there're no need to use hash-table.
Cource context to hash-table if passed context is not hash-table.