### PR TITLE
Fix mustache-lex docstring

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,14 @@ Error checking on invalid sections:
      "{{#outer}}{{#inner}}mismatched!{{/outer}}{{/inner}}"
      (ht)) ;; error "Mismatched brackets: You closed a section with inner, but it wasn't open"
 
+## Alist support
+
+For cusual usage, you can specify using alist for context
+
+    (let ((context '(("name" . "J. Random user"))))
+      (mustache-render "Hello {{name}}!" context))
+    ;;=> "Hello J. Random user!"
+
 ## Todo:
 
 * Errors on unclosed tags

--- a/mustache-lex.el
+++ b/mustache-lex.el
@@ -75,7 +75,7 @@ We return a list of lists: ((:text \"foo\") (:tag \"variable-name\"))"
 
 (defun mst--clean-whitespace (lexemes)
   "Given a list of LEXEMES, remove whitespace around sections and
-comments if they're on their own on a line. Modifies the original
+comments if they're on their own on a line.  Modifies the original
 list."
   ;; iterate over all lexemes:
   (cl-loop for i from 0 to (- (length lexemes) 3)
@@ -100,7 +100,7 @@ list."
   "Returns the text context of a tag.")
 
 (defun mst--no-trailing-newline (lexeme)
-  "Replace \"\n\" or \"\n   \" at the end of a plain text lexeme."
+  "Replace \"\n\" or \"\n   \" at the end of a plain text LEXEME."
   (list
    :text
    (replace-regexp-in-string "\n *$" "" (mst--tag-text lexeme))))
@@ -159,7 +159,7 @@ Note that the lexer converts {{{foo}}} to {{& foo}}."
 ;; fixme: assumes the delimeters haven't changed
 ;; fixme: mst--lex doens't preserve whitespace
 (defun mst--unlex (lexemes)
-  "Given a lexed (and optionally parsed) list of lexemes,
+  "Given a lexed (and optionally parsed) list of LEXEMES,
 return the original input string."
   (if lexemes
       (let ((lexeme (cl-first lexemes))

--- a/mustache-render.el
+++ b/mustache-render.el
@@ -79,6 +79,8 @@ Partials are searched for in `mustache-partial-paths'."
 
 (defun mst--context-get (context variable-name &optional default)
   "Lookup VARIABLE-NAME in CONTEXT, returning DEFAULT if not present."
+  (unless (ht-p context)
+    (setq context (ht<-alist context)))
   (when (eq mustache-key-type 'keyword)
     (setq variable-name (intern (concat ":" variable-name))))
   (ht-get context variable-name default))


### PR DESCRIPTION
Fix mustache-lex docstring

### before
```
 mustache-lex.el    77     info            First line is not a complete sentence (emacs-lisp-checkdoc)
 mustache-lex.el    78     info            There should be two spaces after a period (emacs-lisp-checkdoc)
 mustache-lex.el   103     info            Argument ‘lexeme’ should appear (as LEXEME) in the doc string (emacs-lisp-checkdoc)
 mustache-lex.el   162     info            First line is not a complete sentence (emacs-lisp-checkdoc)
 mustache-lex.el   162     info            Argument ‘lexemes’ should appear (as LEXEMES) in the doc string (emacs-lisp-checkdoc)
```

### after
```
 mustache-lex.el    77     info            First line is not a complete sentence (emacs-lisp-checkdoc)
 mustache-lex.el   162     info            First line is not a complete sentence (emacs-lisp-checkdoc)
```