### PR TITLE
Use `map.el` instead of `ht` to allow more context formats

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,11 +7,11 @@ jobs:
     strategy:
       matrix:
         emacs_version:
-          - '25.2'
-          - '25.3'
-          - '26.1'
-          - '26.2'
-          - '26.3'
+          # - '25.2'
+          # - '25.3'
+          # - '26.1'
+          # - '26.2'
+          # - '26.3'
           - '27.1'
     steps:
     - uses: actions/checkout@v2

--- a/Cask
+++ b/Cask
@@ -4,7 +4,6 @@
 
 (depends-on "s" "1.3.0")
 (depends-on "dash" "1.2.0")
-(depends-on "ht" "0.9")
 
 (development
  (depends-on "f")

--- a/README.md
+++ b/README.md
@@ -1,48 +1,49 @@
 # mustache.el [![Coverage Status](https://coveralls.io/repos/github/Wilfred/mustache.el/badge.svg)](https://coveralls.io/github/Wilfred/mustache.el)
-#### *a mustache templating library in Emacs Lisp*
+
+#### _a mustache templating library in Emacs Lisp_
 
 Targeting [v.1.0.2](https://github.com/mustache/spec/tree/v1.0.2) of Mustache.
 
 ## Example usage
 
-``` emacs-lisp
+```emacs-lisp
 (require 'mustache)
-(require 'ht) ;; hash table library
 
-(let ((context (ht ("name" "J. Random user"))))
+(let ((context '(("name" . "J. Random user"))))
   ;; evaluates to: "Hello J. Random user!"
   (mustache-render "Hello {{name}}!" context))
 ```
 
-### (Optional) Without ht
+`context` can be anything that Emacs's [map manipulation
+functions](https://github.com/emacs-mirror/emacs/blob/master/lisp/emacs-lisp/map.el)
+accept: alists (as in the example above), hash tables, and (if using keyword
+arguments — see below) plists.
 
-You're not forced to use `ht`, it's just an easier way of creating
-hash tables. You can use Emacs' reader syntax for hash tables instead:
-      
-``` emacs-lisp
-(require 'mustache)
+Example with hash tables:
 
+```emacs-lisp
 (let ((context
        #s(hash-table test equal data ("name" "J. Random user"))))
   ;; evaluates to: "Hello J. Random user!"
   (mustache-render "Hello {{name}}!" context))
 ```
 
-Note that hash tables default to using `eql` as the key comparison
-function. You must set it to `equal` since mustache.el uses hash
-tables with string keys.
-
 ### Keywords in context
 
-You can use keywords in contexts, which allows you to skip setting the
-key comparison function.
+You can use keywords in alist and plist contexts:
 
-``` emacs-lisp
+```emacs-lisp
 (require 'mustache)
 
+;; Using an alist
 (let ((mustache-key-type 'keyword)
-      (context
-       #s(hash-table data (:name "J. Random user"))))
+      (context '((:name . "J. Random user"))))
+  ;; evaluates to: "Hello J. Random user!"
+  (mustache-render "Hello {{name}}!" context))
+
+;; Using a plist
+(let ((mustache-key-type 'keyword)
+      (context '(:name "J. Random user")))
   ;; evaluates to: "Hello J. Random user!"
   (mustache-render "Hello {{name}}!" context))
 ```
@@ -51,130 +52,139 @@ key comparison function.
 
 Basic variable interpolation:
 
-``` emacs-lisp
+```emacs-lisp
 (mustache-render
  "Coded with {{language}}!"
- (ht ("language" "elisp"))) ;; "Coded with elisp!"
+ '(("language" . "elisp"))) ;; "Coded with elisp!"
 ```
-     
+
 Blocks with booleans:
 
-``` emacs-lisp
+```emacs-lisp
 (mustache-render
  "{{#is-sunny}}Looks nice today.{{/is-sunny}}"
- (ht ("is-sunny" t))) ;; "Looks nice today."
-
-(mustache-render
- "{{#is-sunny}}Looks nice today.{{/is-sunny}}"
- (ht ("is-sunny" nil))) ;; ""
+ '(("is-sunny" . t))) ;; "Looks nice today."
 ```
-     
-Blocks with hash tables:
 
-``` emacs-lisp
+Blocks with maps:
+
+```emacs-lisp
+;; Using alists
 (mustache-render
  "{{#user}}{{name}}{{/user}}"
- (ht ("user"
-      (ht ("name" "Wilfred"))))) ;; "Wilfred"
+ '(("user" ("name" . "Wilfred")))) ;; "Wilfred"
+
+ ;; Using plists
+(let ((mustache-key-type 'keyword))
+  (mustache-render
+    "{{#user}}{{name}}{{/user}}"
+    '(:user (:name "Wilfred")))) ;; "Wilfred"
 ```
-     
+
 Blocks with lists:
 
-``` emacs-lisp
+```emacs-lisp
+;; Using alists
 (mustache-render
  "{{#some-list}}{{item}}{{/some-list}}"
- (ht ("some-list"
-      (list
-       (ht ("item" "a"))
-       (ht ("item" "b"))
-       (ht ("item" "c")))))) ;; "abc"
+ '(("some-list" . ((("item" . "a"))
+                   (("item" . "b"))
+                   (("item" . "c")))))) ;; "abc"
+
+;; Using plists
+(let ((mustache-key-type 'keyword))
+  (mustache-render
+   "{{#some-list}}{{item}}{{/some-list}}"
+   '(:some-list ((:item "a")
+                 (:item "b")
+                 (:item "c"))))) ;; "abc"
 ```
 
 Inverted blocks:
 
-``` emacs-lisp
+```emacs-lisp
 (mustache-render
  "{{^is-sunny}}Take an umbrella!{{/is-sunny}}"
- (ht ("is-sunny" nil))) ;; "Take an umbrella!"
+ '(("is-sunny" . nil))) ;; "Take an umbrella!"
 
 (mustache-render
  "{{^is-sunny}}Take an umbrella!{{/is-sunny}}"
- (ht ("is-sunny" t))) ;; ""
+ '(("is-sunny" . t))) ;; ""
 ```
 
 Mustache variables are escaped:
 
-``` emacs-lisp
+```emacs-lisp
 (mustache-render
  "{{info}}"
- (ht ("info" "<p>We use mustache</p>"))) ;; "&lt;p&gt;We use mustache&lt;/p&gt;"
+ '(("info" . "<p>We use mustache</p>"))) ;; "&lt;p&gt;We use mustache&lt;/p&gt;"
 ```
 
 Unless explicitly marked as safe:
 
-``` emacs-lisp
+```emacs-lisp
 (mustache-render
  "{{{info}}}"
- (ht ("info" "<p>We use mustache</p>"))) ;; "<p>We use mustache</p>"
+ '(("info" . "<p>We use mustache</p>"))) ;; "<p>We use mustache</p>"
 
 (mustache-render
  "{{& info }}"
- (ht ("info" "<p>We use mustache</p>"))) ;; "<p>We use mustache</p>"
+ '(("info" . "<p>We use mustache</p>"))) ;; "<p>We use mustache</p>"
 ```
 
 Comments:
 
-``` emacs-lisp
+```emacs-lisp
 (mustache-render
  "hello{{! world }}"
- (ht)) ;; "hello"
+ '()) ;; "hello"
 ```
 
 Partials:
 
-``` emacs-lisp
+```emacs-lisp
 ;; assuming ~/projects/mustache.el/test.mustache exists
 ;; and contains "hello {{user}}"
 (let ((mustache-partial-paths (list "~/projects/mustache.el")))
   (mustache-render
    "{{> test}}"
-   (ht ("user" "wilfred")))) ;; "hello wilfred"
+   '(("user" . "wilfred")))) ;; "hello wilfred"
 ```
 
 Changing delimeters:
 
-``` emacs-lisp
+```emacs-lisp
 (mustache-render
  "{{=<% %>=}}<% style %>"
- (ht ("style" "ERB style!"))) ;; "ERB style!"
+ '(("style" . "ERB style!"))) ;; "ERB style!"
 ```
 
 Lambdas:
 
-``` emacs-lisp
+```emacs-lisp
 (mustache-render
  "{{#wrapped}}{{language}} is great.{{/wrapped}}"
- (ht ("language" "elisp")
-     ("wrapped"
-      (lambda (template context)
-        (concat "<b>" (mustache-render template context) "</b>")))))
+ `(("language" . "elisp")
+   ("wrapped" .
+    ,(lambda (template context)
+      (concat "<b>" (mustache-render template context) "</b>")))))
 ;; "<b>elisp is great.</b>"
 ```
 
 Error checking on invalid sections:
 
-``` emacs-lisp
+```emacs-lisp
 (mustache-render
  "{{#outer}}{{#inner}}mismatched!{{/outer}}{{/inner}}"
- (ht)) ;; error "Mismatched brackets: You closed a section with inner, but it wasn't open"
+ '()) ;; error "Mismatched brackets: You closed a section with inner, but it wasn't open"
 ```
 
 ## Todo:
 
-* Errors on unclosed tags
-* Optional error on missing variables from the context
-* Whitespace (in)sensitivity for windows newlines
-* Run full specification test suite
+- Errors on unclosed tags
+- Optional error on missing variables from the context
+- Whitespace (in)sensitivity for windows newlines
+- Run full specification test suite
 
 ### Running tests
 
@@ -194,8 +204,8 @@ optional parts).
 
 ## Other templating projects
 
-* The `format` function (quick and dirty!)
-* [esxml](https://github.com/tali713/esxml)
-* [elnode](https://github.com/nicferrier/elnode) (docs [here](https://github.com/nicferrier/elnode#sending-files))
-* `s-format` from [s.el](https://github.com/magnars/s.el)
-* [xmlgen](https://github.com/philjackson/xmlgen)
+- The `format` function (quick and dirty!)
+- [esxml](https://github.com/tali713/esxml)
+- [elnode](https://github.com/nicferrier/elnode) (docs [here](https://github.com/nicferrier/elnode#sending-files))
+- `s-format` from [s.el](https://github.com/magnars/s.el)
+- [xmlgen](https://github.com/philjackson/xmlgen)

--- a/mustache.el
+++ b/mustache.el
@@ -5,7 +5,7 @@
 ;; Author: Wilfred Hughes <me@wilfred.me.uk>
 ;; Version: 0.24
 ;; Keywords: convenience mustache template
-;; Package-Requires: ((ht "0.9") (s "1.3.0") (dash "1.2.0"))
+;; Package-Requires: ((emacs "26") (s "1.3.0") (dash "1.2.0"))
 ;; URL: https://github.com/Wilfred/mustache.el
 
 ;; This program is free software; you can redistribute it and/or modify
@@ -42,7 +42,7 @@
 ;;; Code:
 
 (require 's)
-(require 'ht)
+(require 'map)
 (require 'dash)
 (require 'cl-lib)
 
@@ -314,7 +314,7 @@ Partials are searched for in `mustache-partial-paths'."
   "Lookup VARIABLE-NAME in CONTEXT, returning DEFAULT if not present."
   (when (eq mustache-key-type 'keyword)
     (setq variable-name (intern (concat ":" variable-name))))
-  (ht-get context variable-name default))
+  (map-elt context variable-name default))
 
 (defun mst--tag-name (tag-text)
   "Given a tag {{foo}}, {{& foo}} or {{{foo}}}, return \"foo\"."
@@ -350,8 +350,12 @@ Partials are searched for in `mustache-partial-paths'."
 
 (defun mst--context-add (table from-table)
   "Return a copy of TABLE where all the key-value pairs in FROM-TABLE have been set."
-  (let ((new-table (ht-copy table)))
-    (ht-update new-table from-table)
+  (let ((new-table (map-copy table)))
+    (map-do (lambda (k v)
+              ;; `setq' + `map-insert' is more expensive than `map-put!', but
+              ;; `map-put!' appears not to work with alists
+              (setq new-table (map-insert new-table k v)))
+            from-table)
     new-table))
 
 (defun mst--listp (object)
@@ -381,14 +385,14 @@ render it in CONTEXT."
             ((mst--open-section-tag-p section-tag)
              (cond
               ;; if the context is a list of hash tables, render repeatedly
-              ((or (mst--listp context-value) (vectorp context-value))
+              ((mst--sequence-of-maps-p context-value)
                (s-join
                 ""
                 (--map
                  (mst--render-section-list section-contents (mst--context-add context it))
                  context-value)))
               ;; if the context is a hash table, render in that context
-              ((hash-table-p context-value)
+              ((mst--map-p context-value)
                (mst--render-section-list section-contents (mst--context-add context context-value)))
               ;; if the context is a function, call it
               ((functionp context-value)
@@ -417,6 +421,27 @@ render it in CONTEXT."
        (s-replace ">" "&gt;")
        (s-replace "'" "&#39;")
        (s-replace "\"" "&quot;")))
+
+(defun mst--sequence-of-maps-p (object)
+  "Return t if OBJECT is a sequence of maps."
+  (and
+   (not (mst--strict-cons-p object))
+   (not (functionp object))
+   (or (and (listp object)
+            (mst--map-p (car object)))
+       (and (vectorp object)
+            (mst--map-p (aref object 0))))))
+
+(defun mst--strict-cons-p (object)
+  "Return t if OBJECT is a strict cons cell (i.e. not a list)."
+  (and (consp object)
+       (not (listp (cdr object)))))
+
+(defun mst--map-p (object)
+  "Return t if OBJECT is a map."
+  (and (not (functionp object))
+       (not (mst--strict-cons-p object))
+       (mapp object)))
 
 (provide 'mustache)
 ;;; mustache.el ends here

--- a/test/mustache-test.el
+++ b/test/mustache-test.el
@@ -188,8 +188,7 @@ tolerance, e.g. allowing missing variables."
        (mustache-render "{{#blah}}{{/foo}}" context)))))
 
 (ert-deftest mustache-test-variable-escaped ()
-  (let ((contexts (list (ht ("blah" "<bar> &baz ' \""))
-                        #s(hash-table test equal data ("blah" "<bar> &baz ' \""))
+  (let ((contexts (list #s(hash-table test equal data ("blah" "<bar> &baz ' \""))
                         '(("blah" . "<bar> &baz ' \"")))))
     (dolist (context contexts)
       (should

--- a/test/mustache-test.el
+++ b/test/mustache-test.el
@@ -28,279 +28,379 @@
 
 (require 'mustache)
 (require 'ert)
-(require 'ht)
 
 (ert-deftest mustache-test-simple-string ()
   (should (equal "foo" (mustache-render "foo" nil))))
 
 (ert-deftest mustache-test-variable ()
-  (let ((context (ht ("blah" "bar"))))
-    (should
-     (equal
-      "foo bar"
-      (mustache-render "foo {{blah}}" context)))))
+  (let ((contexts (list #s(hash-table test equal data ("blah" "bar"))
+                        '(("blah" . "bar")))))
+    (dolist (context contexts)
+      (should
+       (equal
+        "foo bar"
+        (mustache-render "foo {{blah}}" context))))))
 
 (ert-deftest mustache-malformed-tag ()
   "Don't crash if we have a malformed tag.
 Arguably we could error, but mustache generally errs on error
 tolerance, e.g. allowing missing variables."
-  (mustache-render "}} foo {{" (ht)))
+  (mustache-render "}} foo {{"  #s(hash-table)))
 
 (ert-deftest mustache-test-variable-number ()
-  (let ((context (ht ("blah" 2))))
-    (should
-     (equal
-      "foo 2"
-      (mustache-render "foo {{blah}}" context)))))
+  (let ((contexts (list #s(hash-table test equal data ("blah" 2))
+                        '(("blah" . 2)))))
+    (dolist (context contexts)
+      (should
+       (equal
+        "foo 2"
+        (mustache-render "foo {{blah}}" context))))))
 
 (ert-deftest mustache-test-unescaped-variable-number ()
-  (let ((context (ht ("blah" 2))))
-    (should
-     (equal
-      "foo 2"
-      (mustache-render "foo {{{blah}}}" context)))))
+  (let ((contexts (list #s(hash-table test equal data ("blah" 2))
+                        '(("blah" . 2)))))
+    (dolist (context contexts)
+      (should
+       (equal
+        "foo 2"
+        (mustache-render "foo {{{blah}}}" context))))))
 
 (ert-deftest mustache-test-variable-whitespace ()
-  (let ((context (ht ("blah" "bar"))))
-    (should
-     (equal
-      "foo bar"
-      (mustache-render "foo {{ blah }}" context)))))
+  (let ((contexts (list #s(hash-table test equal data ("blah" "bar"))
+                        '(("blah" . "bar")))))
+    (dolist (context contexts)
+      (should
+       (equal
+        "foo bar"
+        (mustache-render "foo {{ blah }}" context))))))
 
 (ert-deftest mustache-test-variable-missing ()
-  (let ((context (ht-create)))
-    (should
-     (equal
-      "foo "
-      (mustache-render "foo {{blah}}" context)))))
+  (let ((contexts (list #s(hash-table)
+                        '())))
+    (dolist (context contexts)
+      (should
+       (equal
+        "foo "
+        (mustache-render "foo {{blah}}" context))))))
 
 (ert-deftest mustache-test-keyword-variable ()
   (let ((mustache-key-type 'keyword)
-        (context (ht (:blah "bar"))))
-    (should
-     (equal
-      "foo bar"
-      (mustache-render "foo {{blah}}" context)))))
+        (contexts (list #s(hash-table test equal data (:blah "bar"))
+                        '(:blah "bar")
+                        '((:blah . "bar")))))
+    (dolist (context contexts)
+      (should
+       (equal
+        "foo bar"
+        (mustache-render "foo {{blah}}" context))))))
 
 (ert-deftest mustache-test-section-inner-whitespace ()
-  (should
-   (equal
-    "="
-    (mustache-render "{{# boolean }}={{/ boolean }}" (ht ("boolean" t))))))
+  (let ((contexts (list #s(hash-table test equal data ("boolean" t))
+                        '(("boolean" . t)))))
+    (dolist (context contexts)
+      (should
+       (equal
+        "="
+        (mustache-render "{{# boolean }}={{/ boolean }}" context))))))
 
 (ert-deftest mustache-test-standalone-lines ()
-  (should
-   (equal "| This Is
+  (let ((contexts (list #s(hash-table test equal data ("boolean" t))
+                        '(("boolean" . t)))))
+    (dolist (context contexts)
+      (should
+       (equal "| This Is
 |
 | A Line
 "
-          (mustache-render "| This Is
+              (mustache-render "| This Is
 {{#boolean}}
 |
 {{/boolean}}
 | A Line
-" (ht ("boolean" t))))))
+" context))))))
 
 (ert-deftest mustache-test-standalone-lines-inverted ()
-  (should
-   (equal "| This Is
+  (let ((contexts (list #s(hash-table test equal data ("boolean" nil))
+                        '(("boolean" . nil)))))
+    (dolist (context contexts)
+      (should
+       (equal "| This Is
 |
 | A Line
 "
-          (mustache-render "| This Is
+              (mustache-render "| This Is
 {{^boolean}}
 |
 {{/boolean}}
 | A Line
-" (ht ("boolean" nil))))))
+" context))))))
 
 (ert-deftest mustache-test-standalone-lines-leading-whitespace ()
-  (should
-   (equal "| This Is
+  (let ((contexts (list #s(hash-table test equal data ("boolean" t))
+                        '(("boolean" . t)))))
+    (dolist (context contexts)
+      (should
+       (equal "| This Is
 |
 | A Line
 "
-          (mustache-render "| This Is
+              (mustache-render "| This Is
   {{#boolean}}
 |
   {{/boolean}}
 | A Line
-" (ht ("boolean" t))))))
+" context))))))
 
 (ert-deftest mustache-test-standalone-lines-comments ()
-  (should
-   (equal "| This Is
+  (let ((contexts (list #s(hash-table)
+                        '())))
+    (dolist (context contexts)
+      (should
+       (equal "| This Is
 |
 | A Line
 "
-          (mustache-render "| This Is
+              (mustache-render "| This Is
 |
   {{!comment}}
 | A Line
-" (ht)))))
+" context))))))
 
 (ert-deftest mustache-test-extra-section-close ()
-  (should-error
-   (mustache-render "{{/blah}}" (ht-create))))
+  (let ((contexts (list #s(hash-table)
+                        '())))
+    (dolist (context contexts)
+      (should-error
+       (mustache-render "{{/blah}}" context)))))
 
 (ert-deftest mustache-test-extra-section-open ()
-  (should-error
-   (mustache-render "{{#blah}}" (ht-create))))
+  (let ((contexts (list #s(hash-table)
+                        '())))
+    (dolist (context contexts)
+      (should-error
+       (mustache-render "{{#blah}}" context)))))
 
 (ert-deftest mustache-test-mismatched-section-close ()
-  (should-error
-   (mustache-render "{{#blah}}{{/foo}}" (ht-create))))
+  (let ((contexts (list #s(hash-table)
+                        '())))
+    (dolist (context contexts)
+      (should-error
+       (mustache-render "{{#blah}}{{/foo}}" context)))))
 
 (ert-deftest mustache-test-variable-escaped ()
-  (let ((context (ht ("blah" "<bar> &baz ' \""))))
-    (should
-     (equal
-      "&lt;bar&gt; &amp;baz &#39; &quot;"
-      (mustache-render "{{blah}}" context)))))
+  (let ((contexts (list (ht ("blah" "<bar> &baz ' \""))
+                        #s(hash-table test equal data ("blah" "<bar> &baz ' \""))
+                        '(("blah" . "<bar> &baz ' \"")))))
+    (dolist (context contexts)
+      (should
+       (equal
+        "&lt;bar&gt; &amp;baz &#39; &quot;"
+        (mustache-render "{{blah}}" context))))))
 
 (ert-deftest mustache-test-section-hash ()
-  (let ((context (ht ("user"  (ht ("name" "bob"))))))
-    (should
-     (equal
-      "bob"
-      (mustache-render "{{#user}}{{name}}{{/user}}" context)))))
+  (let ((contexts (list #s(hash-table test equal
+                                      data ("user"
+                                            #s(hash-table test equal
+                                                          data ("name" "bob"))))
+                        '(("user" ("name" . "bob"))))))
+    (dolist (context contexts)
+      (should
+       (equal
+        "bob"
+        (mustache-render "{{#user}}{{name}}{{/user}}" context))))))
 
 (ert-deftest mustache-test-section-hash-nested ()
-  (let ((context (ht
-                  ("foo" "bar")
-                  ("user"  (ht ("name" "bob"))))))
-    (should
-     (equal
-      "barbob"
-      (mustache-render "{{#user}}{{foo}}{{name}}{{/user}}" context)))))
+  (let ((contexts (list #s(hash-table test equal
+                                      data ("foo" "bar"
+                                            "user" #s(hash-table test equal
+                                                                 data ("name" "bob"))))
+                        '(("foo" . "bar")
+                          ("user" ("name" . "bob"))))))
+    (dolist (context contexts)
+      (should
+       (equal
+        "barbob"
+        (mustache-render "{{#user}}{{foo}}{{name}}{{/user}}" context))))))
 
 (ert-deftest mustache-test-section-list ()
-  (let ((context (ht ("users" (list (ht ("name" "bob"))
-                                    (ht ("name" "chris")))))))
-    (should
-     (equal
-      "bobchris"
-      (mustache-render "{{#users}}{{name}}{{/users}}" context)))))
+  (let ((contexts (list (let ((hash #s(hash-table test equal)))
+                          (puthash "users"
+                                   (list #s(hash-table test equal
+                                                       data ("name" "bob"))
+                                         #s(hash-table test equal
+                                                       data ("name" "chris")))
+                                   hash)
+                          hash)
+                        '(("users" . ((("name" . "bob"))
+                                      (("name" . "chris"))))))))
+    (dolist (context contexts)
+      (should
+       (equal
+        "bobchris"
+        (mustache-render "{{#users}}{{name}}{{/users}}" context))))))
 
 (ert-deftest mustache-test-section-with-vector ()
   "Vectors should behave the same as a list in a context."
-  (let ((context (ht ("users" `[,(ht ("name" "bob"))
-                                ,(ht ("name" "chris"))]))))
-    (should
-     (equal
-      "bobchris"
-      (mustache-render "{{#users}}{{name}}{{/users}}" context)))))
+  (let ((contexts (list (let ((hash #s(hash-table test equal)))
+                          (puthash "users"
+                                   (vector #s(hash-table test equal
+                                                         data ("name" "bob"))
+                                           #s(hash-table test equal
+                                                         data ("name" "chris")))
+                                   hash)
+                          hash)
+                        `(("users" . [(("name" . "bob"))
+                                      (("name" . "chris"))])))))
+    (dolist (context contexts)
+      (should
+       (equal
+        "bobchris"
+        (mustache-render "{{#users}}{{name}}{{/users}}" context))))))
 
 (ert-deftest mustache-test-unescaped ()
-  (let ((context (ht ("blah" "<bar>"))))
-    (should
-     (equal
-      "<bar>"
-      (mustache-render "{{& blah}}" context)))))
+  (let ((contexts (list #s(hash-table test equal data ("blah" "<bar>"))
+                        '(("blah" . "<bar>")))))
+    (dolist (context contexts)
+      (should
+       (equal
+        "<bar>"
+        (mustache-render "{{& blah}}" context))))))
 
 (ert-deftest mustache-test-triple-mustache ()
-  (let ((context (ht ("blah" "<bar>"))))
-    (should
-     (equal
-      "<bar>"
-      (mustache-render "{{{blah}}}" context)))))
+  (let ((contexts (list #s(hash-table test equal data ("blah" "<bar>"))
+                        '(("blah" . "<bar>")))))
+    (dolist (context contexts)
+      (should
+       (equal
+        "<bar>"
+        (mustache-render "{{{blah}}}" context))))))
 
 (ert-deftest mustache-test-triple-mustache-custom-delimiter ()
-  (let ((context (ht ("name" "wilfred"))))
-    (should
-     (equal
-      "{{{name}}}"
-      (mustache-render "{{=<< >>=}}{{{name}}}" context)))))
+  (let ((contexts (list #s(hash-table test equal data ("name" "wilfred"))
+                        '(("name" . "wilfred")))))
+    (dolist (context contexts)
+      (should
+       (equal
+        "{{{name}}}"
+        (mustache-render "{{=<< >>=}}{{{name}}}" context))))))
 
 (ert-deftest mustache-test-conditional-true ()
-  (let ((context (ht ("yes" 't))))
-    (should
-     (equal
-      "foo bar"
-      (mustache-render "foo {{#yes}}bar{{/yes}}" context)))))
+  (let ((contexts (list #s(hash-table test equal data ("yes" t))
+                        '(("yes" . t)))))
+    (dolist (context contexts)
+      (should
+       (equal
+        "foo bar"
+        (mustache-render "foo {{#yes}}bar{{/yes}}" context))))))
 
 (ert-deftest mustache-test-conditional-false ()
-  (let ((context (ht ("no" nil))))
-    (should
-     (equal
-      "foo "
-      (mustache-render "foo {{#no}}bar{{/no}}" context)))))
+  (let ((contexts (list #s(hash-table test equal data ("no" nil))
+                        '(("no" . nil)))))
+    (dolist (context contexts)
+      (should
+       (equal
+        "foo "
+        (mustache-render "foo {{#no}}bar{{/no}}" context))))))
 
 (ert-deftest mustache-test-conditional-keyword ()
   (let ((mustache-key-type 'keyword)
-        (context (ht (:no nil))))
-    (should
-     (equal
-      "foo "
-      (mustache-render "foo {{#no}}bar{{/no}}" context)))))
+        (contexts (list #s(hash-table test equal data (:no nil))
+                        '(:no nil)
+                        '((:no . nil)))))
+    (dolist (context contexts)
+      (should
+       (equal
+        "foo "
+        (mustache-render "foo {{#no}}bar{{/no}}" context))))))
 
 (ert-deftest mustache-test-inverted ()
-  (let ((context (ht ("no" nil))))
-    (should
-     (equal
-      "foo bar"
-      (mustache-render "foo {{^no}}bar{{/no}}" context)))))
+  (let ((contexts (list #s(hash-table test equal data ("no" nil))
+                        '(("no" . nil)))))
+    (dolist (context contexts)
+      (should
+       (equal
+        "foo bar"
+        (mustache-render "foo {{^no}}bar{{/no}}" context))))))
 
 (ert-deftest mustache-test-comment ()
-  (let ((context (ht-create)))
-    (should
-     (equal
-      ""
-      (mustache-render "{{! whatever}}" context)))))
+  (let ((contexts (list #s(hash-table)
+                        '())))
+    (dolist (context contexts)
+      (should
+       (equal
+        ""
+        (mustache-render "{{! whatever}}" context))))))
 
 (ert-deftest mustache-test-after-comment ()
   "Ensure we render tags after comments.
 Regression test for https://github.com/Wilfred/mustache.el/issues/4."
-  (let ((context  (ht ("b" "hello"))))
-    (should
-     (equal
-      "hello"
-      (mustache-render
-       "{{!<script src=\"somescript.js\" async=\"async\"}}{{b}}" context)))))
+  (let ((contexts (list #s(hash-table test equal data ("b" "hello"))
+                        '(("b" . "hello")))))
+    (dolist (context contexts)
+      (should
+       (equal
+        "hello"
+        (mustache-render
+         "{{!<script src=\"somescript.js\" async=\"async\"}}{{b}}" context))))))
 
 (ert-deftest mustache-test-partial ()
-  (let ((mustache-partial-paths (list default-directory)))
-    (should
-     (equal
-      "hello world"
-      (mustache-render "{{> partial }}" (ht))))))
+  (let ((contexts (list #s(hash-table)
+                        '()))
+        (mustache-partial-paths (list default-directory)))
+    (dolist (context contexts)
+      (should
+       (equal
+        "hello world"
+        (mustache-render "{{> partial }}" context))))))
 
 (ert-deftest mustache-test-partial-path ()
   "Ensure we get the correct partial path, regardless of `default-directory'.
 Regression test for https://github.com/Wilfred/mustache.el/pull/3"
-  (let ((mustache-partial-paths (list default-directory))
+  (let ((contexts (list #s(hash-table)
+                        '()))
+        (mustache-partial-paths (list default-directory))
         (default-directory "/"))
-    (should
-     (equal
-      "hello world"
-      (mustache-render "{{> partial }}" (ht))))))
+    (dolist (context contexts)
+      (should
+       (equal
+        "hello world"
+        (mustache-render "{{> partial }}" context))))))
 
 (ert-deftest mustache-test-partial-rendered ()
   "Test that we render the contents of the partial as a mustache template."
-  (let ((mustache-partial-paths (list default-directory)))
-    (should
-     (equal
-      "hello world"
-      (mustache-render
-       "{{> partial-with-variables }}"
-       (ht ("thing" "world")))))))
+  (let ((contexts (list #s(hash-table test equal data ("thing" "world"))
+                        '(("thing" . "world"))))
+        (mustache-partial-paths (list default-directory)))
+    (dolist (context contexts)
+      (should
+       (equal
+        "hello world"
+        (mustache-render
+         "{{> partial-with-variables }}"
+         context))))))
 
 (ert-deftest mustache-test-change-delimeter ()
-  (should
-   (equal
-    "bar"
-    (mustache-render "{{=<< >>=}}<< foo >>" (ht ("foo" "bar"))))))
+  (let ((contexts (list '(("foo" . "bar")))))
+    (dolist (context contexts)
+      (should
+       (equal
+        "bar"
+        (mustache-render "{{=<< >>=}}<< foo >>" context))))))
 
 (ert-deftest mustache-test-lambda ()
-  (should
-   (equal
-    "<b>Willy is awesome.</b>"
-    (mustache-render
-     "{{#wrapped}}{{name}} is awesome.{{/wrapped}}"
-     (ht ("name" "Willy")
-         ("wrapped"
-          (lambda (template context)
-            (concat "<b>" (mustache-render template context) "</b>"))))))))
+  (let* ((wrapped (lambda (template context)
+                    (concat "<b>" (mustache-render template context) "</b>")))
+         (contexts (list (let ((hash #s(hash-table test equal data ("name" "Willy"))))
+                           (puthash "wrapped" wrapped hash)
+                           hash)
+                         `(("name" . "Willy")
+                           ("wrapped" . ,wrapped)))))
+    (dolist (context contexts)
+      (should
+       (equal
+        "<b>Willy is awesome.</b>"
+        (mustache-render
+         "{{#wrapped}}{{name}} is awesome.{{/wrapped}}" context))))))
 
 (defun mustache-run-tests ()
   (interactive)


### PR DESCRIPTION
Related: https://github.com/Wilfred/mustache.el/issues/22

When adapting tests, I erred on the side of completeness. It doesn't break any previously passing test.

Sorry for the mild reformatting of the README (e.g. `*foo*` → `_foo_`), I had `prettier-mode` on. I'll revert those if needed.



